### PR TITLE
Avoid to break the pipe if no files are passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,7 @@ module.exports = function(filename, options) {
     /* jshint validthis: true, camelcase: false */
     if(!toplevel) {
       gutil.log('gulp-uglifyjs - No files given; aborting minification');
+      this.emit('end');
       return;
     }
 


### PR DESCRIPTION
I'm using this plugin and I got the issue that when I run a task which depends of another task that use `gulp-unglifyjs` it ends the task if no files are found by `gulp-src` hence none is injected in the pipe.

The thing is that if no files and injected it would be fine to follow the pipe and allow to continue the task execution.

I have a task like this:

```js

gulp.task('scripts', ['jshint'], function () {
    return gulp.src('dev/scripts/**/*.js')
    .pipe(gulpPlugins.uglifyjs('bundle.js',{ outSourceMap: true, sourceRoot: '/', basePath: '/dev' }))
    .pipe(gulp.dest('.tmp/scripts'));
  });

 gulp.task('serve', ['styles', 'views', 'scripts'], function () {
    browserSync({
      notify: false,
      open: false, // Don't open the browser windows with the url when staring
      server: ['.tmp', 'dev']
    });

    gulp.watch(['dev/views/**/*.jade'], ['views', reload]);
    gulp.watch(['dev/styles/**/*.{scss,css}'], ['styles', reload]);
    gulp.watch(['dev/scripts/**/*.js'], ['scripts', reload]);
    gulp.watch(['dev/images/**/*'], reload);
    gulp.watch(['dev/fonts/**/*'], reload);
  });
```

So if I run `gulp serve` and `dev/scripts` does not exist or it does not contain any js file then the task is abort and basically gulp does not keep watching, so the workaround is add an empty js file into the directory, but I wouldn't prefer to do that, because sometimes I want to use the same `gulpfile.js` for development which does not include any javascript file.

Although the change doesn't break the test, I don't know if that change is breaking anything that you want to do, for example abort if that happens for any reason.