### PR TITLE
Set the inSourceMap filename if one was requested

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ module.exports = function(filename, options) {
     if (options.outSourceMap) {
       options.output.source_map = options.output.source_map || {
         file: filename,
-        root: options.sourceRoot || baseFile.cwd,
+        root: options.sourceRoot || baseFile.base,
       };
 
       if (options.inSourceMap) {

--- a/index.js
+++ b/index.js
@@ -52,6 +52,11 @@ module.exports = function(filename, options) {
       if (options.outSourceMap === true) {
         options.outSourceMap = filename + '.map';
       }
+
+      // Set the inSourceMap filename if one was requested
+      if (options.inSourceMap === true) {
+        options.inSourceMap = filename + '.map';
+      }
     }
 
     var code = file.contents.toString();

--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ module.exports = function(filename, options) {
       };
 
       if (options.inSourceMap) {
-        options.output.source_map.orig = fs.readFileSync(options.inSourceMap).toString();
+        options.output.source_map.orig = fs.readFileSync(path.join(baseFile.base, options.inSourceMap)).toString();
       }
 
       var map = UglifyJS.SourceMap(options.output.source_map);


### PR DESCRIPTION
The same behavior as `outSourceMap`. Set `inSourceMap` to `true` and the source map name will be the same as the output file name suffixed with .map.

This allows source maps already generated with webpack, gulp-rev, or other tools that use hashes in the output filenames and map filenames.
